### PR TITLE
Phone number update for Android devices

### DIFF
--- a/_includes/header/header.html
+++ b/_includes/header/header.html
@@ -13,7 +13,7 @@
               <li><a href="colateral">co.lateral</a></li>
               <li><a href="about">About</a></li>
               <li><a href="contact">Contact</a></li>
-              <li><a id="phone" href="tel:+44 330 056 3800">+44 (0) 330 056 3800</a></li>
+              <li><a id="phone" href="tel:+443300563800">+44 (0) 330 056 3800</a></li>
               <li><a id="button" href="book-a-demo" class="button">Book a demo</a></li>
             </ul>
           </div>
@@ -39,7 +39,7 @@
               <li><a href="colateral">co.lateral</a></li>
               <li><a href="about">About</a></li>
               <li><a href="contact">Contact</a></li>
-              <li><a id="phone" href="tel:+44 330 056 3800">+44 (0) 330 056 3800</a></li>
+              <li><a id="phone" href="tel:+443300563800">+44 (0) 330 056 3800</a></li>
               <li><a id="button" href="book-a-demo" class="button">Book a demo</a></li>
             </ul>
         </div>

--- a/_includes/header/header.html
+++ b/_includes/header/header.html
@@ -13,7 +13,7 @@
               <li><a href="colateral">co.lateral</a></li>
               <li><a href="about">About</a></li>
               <li><a href="contact">Contact</a></li>
-              <li><a id="phone" href="tel:+44 (0) 330 056 3800">+44 (0) 330 056 3800</a></li>
+              <li><a id="phone" href="tel:+44 330 056 3800">+44 (0) 330 056 3800</a></li>
               <li><a id="button" href="book-a-demo" class="button">Book a demo</a></li>
             </ul>
           </div>
@@ -39,7 +39,7 @@
               <li><a href="colateral">co.lateral</a></li>
               <li><a href="about">About</a></li>
               <li><a href="contact">Contact</a></li>
-              <li><a id="phone" href="tel:+44 (0) 330 056 3800">+44 (0) 330 056 3800</a></li>
+              <li><a id="phone" href="tel:+44 330 056 3800">+44 (0) 330 056 3800</a></li>
               <li><a id="button" href="book-a-demo" class="button">Book a demo</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Removed the (0) in the phone number link to just be +44. The phone number should only appear in the header section of the website.